### PR TITLE
Add collision tags to URDF

### DIFF
--- a/urdf/marty.urdf
+++ b/urdf/marty.urdf
@@ -10,8 +10,16 @@
         <color rgba="0.07 0.52 .625 1"/>
       </material>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/base.stl"/>
+      </geometry>
+      <origin rpy="1.57075 0 1.57075" xyz="-0.05 -0.0635 0"/>
+      <material name="blue">
+        <color rgba="0.07 0.52 .625 1"/>
+      </material>
+    </collision>
   </link>
-
   <joint name="face_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.047 0.0015 0.075"/>
     <axis xyz="0 1 0"/>
@@ -19,39 +27,48 @@
     <parent link="base_link"/>
     <child link="face"/>
   </joint>
-
   <link name="face">
     <visual>
       <geometry>
         <mesh filename="package://marty_description/meshes/face.stl"/>
       </geometry>
       <material name="blue"/>
-    <origin rpy="1.57075 0 1.57075" xyz="-0.003 -0.0655 -0.075"/>
+      <origin rpy="1.57075 0 1.57075" xyz="-0.003 -0.0655 -0.075"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/face.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57075 0 1.57075" xyz="-0.003 -0.0655 -0.075"/>
+    </collision>
   </link>
-
   <joint name="rpi_camera_mount_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.012 0 0.002"/>
     <parent link="base_link"/>
     <child link="rpi_camera_mount"/>
   </joint>
-
   <link name="rpi_camera_mount">
     <visual>
       <geometry>
         <mesh filename="package://marty_description/meshes/rpiCameraMount.stl"/>
       </geometry>
       <material name="blue"/>
-    <origin rpy="1.57075 0 0" xyz="0 0.0125 0"/>
+      <origin rpy="1.57075 0 0" xyz="0 0.0125 0"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/rpiCameraMount.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57075 0 0" xyz="0 0.0125 0"/>
+    </collision>
   </link>
-
   <joint name="left_side_panel_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.006 0.0575 0.0375"/>
     <parent link="base_link"/>
     <child link="left_side_panel"/>
   </joint>
-
   <link name="left_side_panel">
     <visual>
       <geometry>
@@ -62,8 +79,16 @@
       </material>
       <origin rpy="1.57075 0 -1.57075" xyz="0.0437 0.005 -0.0375"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/sidePanel.stl"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba=".8 .8 0 1"/>
+      </material>
+      <origin rpy="1.57075 0 -1.57075" xyz="0.0437 0.005 -0.0375"/>
+    </collision>
   </link>
-
   <joint name="left_arm_servo_gear_joint" type="revolute">
     <origin rpy="-1.57 0.085 0" xyz="0 0.002 0.014"/>
     <axis xyz="0 0 1"/>
@@ -71,17 +96,22 @@
     <parent link="left_side_panel"/>
     <child link="left_arm_servo_gear"/>
   </joint>
-
   <link name="left_arm_servo_gear">
     <visual>
       <geometry>
         <mesh filename="package://marty_description/meshes/armServoGear.stl"/>
       </geometry>
       <material name="yellow"/>
-    <origin rpy="0 1.57 0" xyz="-0.02 -0.02 0.003"/>
+      <origin rpy="0 1.57 0" xyz="-0.02 -0.02 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/armServoGear.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="0 1.57 0" xyz="-0.02 -0.02 0.003"/>
+    </collision>
   </link>
-
   <joint name="left_arm_gear_joint" type="revolute">
     <origin rpy="-1.57075 0 0" xyz="0 0 -0.021"/>
     <mimic joint="left_arm_servo_gear_joint" multiplier="-1.1875" offset="0"/>
@@ -90,23 +120,27 @@
     <parent link="left_side_panel"/>
     <child link="left_arm_gear"/>
   </joint>
-
   <link name="left_arm_gear">
     <visual>
       <geometry>
         <mesh filename="package://marty_description/meshes/armGear.stl"/>
       </geometry>
       <material name="yellow"/>
-    <origin rpy="0 0 0" xyz="-0.017 -0.017 -0.002"/>
+      <origin rpy="0 0 0" xyz="-0.017 -0.017 -0.002"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/armGear.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="0 0 0" xyz="-0.017 -0.017 -0.002"/>
+    </collision>
   </link>
-
   <joint name="left_arm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="left_arm_gear"/>
     <child link="left_arm"/>
   </joint>
-
   <link name="left_arm">
     <visual>
       <geometry>
@@ -115,14 +149,19 @@
       <material name="yellow"/>
       <origin rpy="-0.35 0 3.1415" xyz="0.0125 0.0585 0.02"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/arm.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="-0.35 0 3.1415" xyz="0.0125 0.0585 0.02"/>
+    </collision>
   </link>
-
   <joint name="left_hand_joint" type="fixed">
     <origin rpy="0.35 0 0" xyz="0 0.058 0.03"/>
     <parent link="left_arm"/>
     <child link="left_hand"/>
   </joint>
-
   <link name="left_hand">
     <visual>
       <geometry>
@@ -131,14 +170,19 @@
       <material name="yellow"/>
       <origin rpy="0 0 3.1415" xyz="0.013125 0.0189 -0.006"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/hand.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="0 0 3.1415" xyz="0.013125 0.0189 -0.006"/>
+    </collision>
   </link>
-
   <joint name="right_side_panel_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.006 -0.055 0.0375"/>
     <parent link="base_link"/>
     <child link="right_side_panel"/>
   </joint>
-
   <link name="right_side_panel">
     <visual>
       <geometry>
@@ -147,10 +191,18 @@
       <material name="yellow">
         <color rgba=".8 .8 0 1"/>
       </material>
-    <origin rpy="1.57075 0 1.57075" xyz="-0.0437 -0.0075 -0.0375"/>
+      <origin rpy="1.57075 0 1.57075" xyz="-0.0437 -0.0075 -0.0375"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/sidePanel.stl"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba=".8 .8 0 1"/>
+      </material>
+      <origin rpy="1.57075 0 1.57075" xyz="-0.0437 -0.0075 -0.0375"/>
+    </collision>
   </link>
-
   <joint name="right_arm_servo_gear_joint" type="revolute">
     <origin rpy="1.57075 -3.055 0" xyz="0 -0.0035 0.014"/>
     <axis xyz="0 0 1"/>
@@ -158,17 +210,22 @@
     <parent link="right_side_panel"/>
     <child link="right_arm_servo_gear"/>
   </joint>
-
   <link name="right_arm_servo_gear">
     <visual>
       <geometry>
         <mesh filename="package://marty_description/meshes/armServoGear.stl"/>
       </geometry>
       <material name="yellow"/>
-    <origin rpy="0 1.57075 0" xyz="-0.02 -0.02 0.003"/>
+      <origin rpy="0 1.57075 0" xyz="-0.02 -0.02 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/armServoGear.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="0 1.57075 0" xyz="-0.02 -0.02 0.003"/>
+    </collision>
   </link>
-
   <joint name="right_arm_gear_joint" type="revolute">
     <mimic joint="right_arm_servo_gear_joint" multiplier="-1.1875" offset="0"/>
     <origin rpy="1.57075 -3.1415 0" xyz="0 -0.0015 -0.021"/>
@@ -177,23 +234,27 @@
     <parent link="right_side_panel"/>
     <child link="right_arm_gear"/>
   </joint>
-
   <link name="right_arm_gear">
     <visual>
       <geometry>
         <mesh filename="package://marty_description/meshes/armGear.stl"/>
       </geometry>
       <material name="yellow"/>
-    <origin rpy="0 0 0" xyz="-0.017 -0.017 -0.002"/>
+      <origin rpy="0 0 0" xyz="-0.017 -0.017 -0.002"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/armGear.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="0 0 0" xyz="-0.017 -0.017 -0.002"/>
+    </collision>
   </link>
-
   <joint name="right_arm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="right_arm_gear"/>
     <child link="right_arm"/>
   </joint>
-
   <link name="right_arm">
     <visual>
       <geometry>
@@ -202,14 +263,19 @@
       <material name="yellow"/>
       <origin rpy="-0.35 0 3.1415" xyz="0.0125 0.0585 0.02"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/arm.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="-0.35 0 3.1415" xyz="0.0125 0.0585 0.02"/>
+    </collision>
   </link>
-
   <joint name="right_hand_joint" type="fixed">
     <origin rpy="0.35 0 0" xyz="0 0.058 0.03"/>
     <parent link="right_arm"/>
     <child link="right_hand"/>
   </joint>
-
   <link name="right_hand">
     <visual>
       <geometry>
@@ -218,8 +284,14 @@
       <material name="yellow"/>
       <origin rpy="0 0 3.1415" xyz="0.013125 0.0189 -0.006"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/hand.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="0 0 3.1415" xyz="0.013125 0.0189 -0.006"/>
+    </collision>
   </link>
-
   <joint name="right_eye_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0.079 -0.02425 -0.0275"/>
     <mimic joint="left_eye_joint" multiplier="-1" offset="0"/>
@@ -228,7 +300,6 @@
     <parent link="face"/>
     <child link="right_eye"/>
   </joint>
-
   <link name="right_eye">
     <visual>
       <geometry>
@@ -239,8 +310,16 @@
       </material>
       <origin rpy="1.57 -0.06 -1.57" xyz="0.0037 0.022 -0.025"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/eyeRight.stl"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+      <origin rpy="1.57 -0.06 -1.57" xyz="0.0037 0.022 -0.025"/>
+    </collision>
   </link>
-
   <joint name="left_eye_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0.079 0.02125 -0.0275"/>
     <axis xyz="1 0 0"/>
@@ -248,20 +327,22 @@
     <parent link="face"/>
     <child link="left_eye"/>
   </joint>
-
   <link name="left_eye">
     <visual>
       <geometry>
         <mesh filename="package://marty_description/meshes/eyeLeft.stl"/>
       </geometry>
       <material name="white"/>
-      <!-- <origin rpy="0 1.57075 0" xyz="0 -0.0235 0.0235"/> -->
       <origin rpy="1.57 -0.02 1.57" xyz="0 -0.023 -0.0238"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/eyeLeft.stl"/>
+      </geometry>
+      <material name="white"/>
+      <origin rpy="1.57 -0.02 1.57" xyz="0 -0.023 -0.0238"/>
+    </collision>
   </link>
-
-  <!-- LEFT HIP -->
-
   <joint name="left_hip_servo_holder_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.0075 0.01825 -0.015"/>
     <parent link="base_link"/>
@@ -275,8 +356,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 3.1415" xyz="0.0282 -0.00825 -0.0095"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 3.1415" xyz="0.0282 -0.00825 -0.0095"/>
+    </collision>
   </link>
-
   <joint name="left_hip_servo_mount_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.0075 0.03825 -0.015"/>
     <parent link="base_link"/>
@@ -290,8 +377,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 0" xyz="-0.0258 0.0078   -0.0095"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoMount.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 0" xyz="-0.0258 0.0078   -0.0095"/>
+    </collision>
   </link>
-
   <joint name="left_hip_link1_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0.00925 0 0.00376"/>
     <mimic joint="left_hip_servo_link_joint" multiplier="1" offset="0"/>
@@ -308,8 +401,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 0" xyz="-0.003 -0.0121 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 0" xyz="-0.003 -0.0121 0.003"/>
+    </collision>
   </link>
-
   <joint name="left_hip_link2_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.0069 0 0.00376"/>
     <mimic joint="left_hip_servo_link_joint" multiplier="1" offset="0"/>
@@ -326,8 +425,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 0" xyz="0.003 -0.0121 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 0" xyz="0.003 -0.0121 -0.053"/>
+    </collision>
   </link>
-
   <joint name="left_hip_link3_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.007 0 0.00376"/>
     <mimic joint="left_hip_servo_link_joint" multiplier="1" offset="0"/>
@@ -344,8 +449,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 3.1415" xyz="0.0031 0.0116 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 3.1415" xyz="0.0031 0.0116 0.003"/>
+    </collision>
   </link>
-
   <joint name="left_hip_servo_link_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0.00925 0 0.00376"/>
     <axis xyz="0 1 0"/>
@@ -361,8 +472,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 3.1415" xyz="-0.005 0.0116 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoLink.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 3.1415" xyz="-0.005 0.0116 -0.053"/>
+    </collision>
   </link>
-
   <joint name="left_hip_crossbrace1_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 -0.01 -0.025"/>
     <parent link="left_hip_servo_link"/>
@@ -376,8 +493,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 1.57" xyz="0.0031 -0.0204 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 1.57" xyz="0.0031 -0.0204 -0.0125"/>
+    </collision>
   </link>
-
   <joint name="left_hip_crossbrace2_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 -0.01 -0.025"/>
     <parent link="left_hip_link3"/>
@@ -391,10 +514,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 -1.57" xyz="-0.0031 0.0199 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 -1.57" xyz="-0.0031 0.0199 -0.0125"/>
+    </collision>
   </link>
-
-  <!-- LEFT TWIST -->
-
   <joint name="left_twist_servo_holder1_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.05"/>
     <axis xyz="0 1 0"/>
@@ -411,8 +538,14 @@
       <material name="blue"/>
       <origin rpy="1.57 3.1415 0" xyz="0.0188 0.00785 0.013"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 3.1415 0" xyz="0.0188 0.00785 0.013"/>
+    </collision>
   </link>
-
   <joint name="left_twist_servo_holder2_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 -0.02 0"/>
     <parent link="left_twist_servo_holder1"/>
@@ -426,8 +559,14 @@
       <material name="blue"/>
       <origin rpy="-1.57 0 0" xyz="-0.035225 -0.00825 0.013"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="-1.57 0 0" xyz="-0.035225 -0.00825 0.013"/>
+    </collision>
   </link>
-
   <joint name="left_twist_shaft_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.009 -0.01 -0.0164"/>
     <axis xyz="0 0 1"/>
@@ -445,10 +584,16 @@
       </material>
       <origin rpy="1.57 0 -1.57" xyz="0.01635 0.01325 0"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/twistShaft.stl"/>
+      </geometry>
+      <material name="orange">
+        <color rgba="0.84 0.41 0.14 1"/>
+      </material>
+      <origin rpy="1.57 0 -1.57" xyz="0.01635 0.01325 0"/>
+    </collision>
   </link>
-
-  <!-- LEFT KNEE -->
-
   <joint name="left_knee_servo_holder_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.01 0.008 -0.0062"/>
     <parent link="left_twist_shaft"/>
@@ -462,8 +607,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 -1.57" xyz="0.00855 0.01885 -0.0133"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 -1.57" xyz="0.00855 0.01885 -0.0133"/>
+    </collision>
   </link>
-
   <joint name="left_knee_servo_mount_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.0099 0.008 -0.0062"/>
     <parent link="left_twist_shaft"/>
@@ -477,8 +628,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 1.57" xyz="-0.0075825 -0.0351 -0.0133"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoMount.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 1.57" xyz="-0.0075825 -0.0351 -0.0133"/>
+    </collision>
   </link>
-
   <joint name="left_knee_link1_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <mimic joint="left_knee_servo_link_joint" multiplier="1" offset="0"/>
@@ -495,8 +652,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 1.57" xyz="0.0123 -0.003 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 1.57" xyz="0.0123 -0.003 0.003"/>
+    </collision>
   </link>
-
   <joint name="left_knee_link2_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.01615 0"/>
     <mimic joint="left_knee_servo_link_joint" multiplier="1" offset="0"/>
@@ -513,8 +676,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 1.57" xyz="0.0123 0.00291 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 1.57" xyz="0.0123 0.00291 -0.053"/>
+    </collision>
   </link>
-
   <joint name="left_knee_link3_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.005 -0.01615 0"/>
     <mimic joint="left_knee_servo_link_joint" multiplier="1" offset="0"/>
@@ -531,8 +700,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 -1.57" xyz="-0.0064 0.00291 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 -1.57" xyz="-0.0064 0.00291 0.003"/>
+    </collision>
   </link>
-
   <joint name="left_knee_servo_link_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.005 0 0"/>
     <axis xyz="1 0 0"/>
@@ -548,8 +723,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 -1.57" xyz="-0.0064 -0.005 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoLink.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 -1.57" xyz="-0.0064 -0.005 -0.053"/>
+    </collision>
   </link>
-
   <joint name="left_knee_crossbrace1_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.015 0.01 -0.025"/>
     <parent link="left_knee_servo_link"/>
@@ -563,8 +744,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 -3.1415" xyz="0.02075 -0.0067 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 -3.1415" xyz="0.02075 -0.0067 -0.0125"/>
+    </collision>
   </link>
-
   <joint name="left_knee_crossbrace2_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.015 -0.01 -0.025"/>
     <parent link="left_knee_link3"/>
@@ -578,8 +765,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 0" xyz="-0.01925 0.0067 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 0" xyz="-0.01925 0.0067 -0.0125"/>
+    </collision>
   </link>
-
   <joint name="left_foot_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.05"/>
     <mimic joint="left_knee_servo_link_joint" multiplier="-1" offset="0"/>
@@ -596,10 +789,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 3.1415" xyz="0.0635 -0.0306 -0.00725"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/foot.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 3.1415" xyz="0.0635 -0.0306 -0.00725"/>
+    </collision>
   </link>
-
-  <!-- RIGHT HIP -->
-
   <joint name="right_hip_servo_holder_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.0075 -0.03825 -0.015"/>
     <parent link="base_link"/>
@@ -613,8 +810,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 3.1415" xyz="0.0282 -0.00825 -0.0095"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 3.1415" xyz="0.0282 -0.00825 -0.0095"/>
+    </collision>
   </link>
-
   <joint name="right_hip_servo_mount_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.0075 -0.01825 -0.015"/>
     <parent link="base_link"/>
@@ -628,8 +831,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 0" xyz="-0.0258 0.0078   -0.0095"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoMount.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 0" xyz="-0.0258 0.0078   -0.0095"/>
+    </collision>
   </link>
-
   <joint name="right_hip_link1_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0.00925 0 0.00376"/>
     <mimic joint="right_hip_servo_link_joint" multiplier="1" offset="0"/>
@@ -646,8 +855,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 0" xyz="-0.003 -0.0121 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 0" xyz="-0.003 -0.0121 0.003"/>
+    </collision>
   </link>
-
   <joint name="right_hip_link2_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.0069 0 0.00376"/>
     <mimic joint="right_hip_servo_link_joint" multiplier="1" offset="0"/>
@@ -664,8 +879,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 0" xyz="0.003 -0.0121 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 0" xyz="0.003 -0.0121 -0.053"/>
+    </collision>
   </link>
-
   <joint name="right_hip_link3_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.007 0 0.00376"/>
     <mimic joint="right_hip_servo_link_joint" multiplier="1" offset="0"/>
@@ -682,8 +903,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 3.1415" xyz="0.0031 0.0116 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 3.1415" xyz="0.0031 0.0116 0.003"/>
+    </collision>
   </link>
-
   <joint name="right_hip_servo_link_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0.00925 0 0.00376"/>
     <axis xyz="0 1 0"/>
@@ -699,8 +926,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 3.1415" xyz="-0.005 0.0116 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoLink.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 3.1415" xyz="-0.005 0.0116 -0.053"/>
+    </collision>
   </link>
-
   <joint name="right_hip_crossbrace1_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 -0.01 -0.025"/>
     <parent link="right_hip_servo_link"/>
@@ -714,8 +947,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 1.57" xyz="0.0031 -0.0204 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 1.57" xyz="0.0031 -0.0204 -0.0125"/>
+    </collision>
   </link>
-
   <joint name="right_hip_crossbrace2_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 -0.01 -0.025"/>
     <parent link="right_hip_link3"/>
@@ -729,10 +968,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 -1.57" xyz="-0.0031 0.0199 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 -1.57" xyz="-0.0031 0.0199 -0.0125"/>
+    </collision>
   </link>
-
-  <!-- RIGHT TWIST -->
-
   <joint name="right_twist_servo_holder1_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.05"/>
     <axis xyz="0 1 0"/>
@@ -749,8 +992,14 @@
       <material name="blue"/>
       <origin rpy="1.57 3.1415 0" xyz="0.0188 0.00785 0.013"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 3.1415 0" xyz="0.0188 0.00785 0.013"/>
+    </collision>
   </link>
-
   <joint name="right_twist_servo_holder2_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 -0.02 0"/>
     <parent link="right_twist_servo_holder1"/>
@@ -764,8 +1013,14 @@
       <material name="blue"/>
       <origin rpy="-1.57 0 0" xyz="-0.035225 -0.00825 0.013"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="-1.57 0 0" xyz="-0.035225 -0.00825 0.013"/>
+    </collision>
   </link>
-
   <joint name="right_twist_shaft_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.009 -0.01 -0.0164"/>
     <axis xyz="0 0 1"/>
@@ -783,10 +1038,16 @@
       </material>
       <origin rpy="1.57 0 -1.57" xyz="0.01635 0.01325 0"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/twistShaft.stl"/>
+      </geometry>
+      <material name="orange">
+        <color rgba="0.84 0.41 0.14 1"/>
+      </material>
+      <origin rpy="1.57 0 -1.57" xyz="0.01635 0.01325 0"/>
+    </collision>
   </link>
-
-  <!-- RIGHT KNEE -->
-
   <joint name="right_knee_servo_holder_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.01 0.008 -0.0062"/>
     <parent link="right_twist_shaft"/>
@@ -800,8 +1061,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 -1.57" xyz="0.00855 0.01885 -0.0133"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoHolder.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 -1.57" xyz="0.00855 0.01885 -0.0133"/>
+    </collision>
   </link>
-
   <joint name="right_knee_servo_mount_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.0099 0.008 -0.0062"/>
     <parent link="right_twist_shaft"/>
@@ -815,8 +1082,14 @@
       <material name="blue"/>
       <origin rpy="1.57 0 1.57" xyz="-0.0075825 -0.0351 -0.0133"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoMount.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 1.57" xyz="-0.0075825 -0.0351 -0.0133"/>
+    </collision>
   </link>
-
   <joint name="right_knee_link1_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <mimic joint="right_knee_servo_link_joint" multiplier="1" offset="0"/>
@@ -833,8 +1106,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 1.57" xyz="0.0123 -0.003 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 1.57" xyz="0.0123 -0.003 0.003"/>
+    </collision>
   </link>
-
   <joint name="right_knee_link2_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.01615 0"/>
     <mimic joint="right_knee_servo_link_joint" multiplier="1" offset="0"/>
@@ -851,8 +1130,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 1.57" xyz="0.0123 0.00291 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 1.57" xyz="0.0123 0.00291 -0.053"/>
+    </collision>
   </link>
-
   <joint name="right_knee_link3_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.005 -0.01615 0"/>
     <mimic joint="right_knee_servo_link_joint" multiplier="1" offset="0"/>
@@ -869,8 +1154,14 @@
       <material name="blue"/>
       <origin rpy="0 1.57 -1.57" xyz="-0.0064 0.00291 0.003"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/link.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 1.57 -1.57" xyz="-0.0064 0.00291 0.003"/>
+    </collision>
   </link>
-
   <joint name="right_knee_servo_link_joint" type="revolute">
     <origin rpy="0 0 0" xyz="-0.005 0 0"/>
     <axis xyz="1 0 0"/>
@@ -886,8 +1177,14 @@
       <material name="blue"/>
       <origin rpy="0 -1.57 -1.57" xyz="-0.0064 -0.005 -0.053"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/servoLink.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="0 -1.57 -1.57" xyz="-0.0064 -0.005 -0.053"/>
+    </collision>
   </link>
-
   <joint name="right_knee_crossbrace1_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.015 0.01 -0.025"/>
     <parent link="right_knee_servo_link"/>
@@ -901,8 +1198,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 -3.1415" xyz="0.02075 -0.0067 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 -3.1415" xyz="0.02075 -0.0067 -0.0125"/>
+    </collision>
   </link>
-
   <joint name="right_knee_crossbrace2_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.015 -0.01 -0.025"/>
     <parent link="right_knee_link3"/>
@@ -916,8 +1219,14 @@
       <material name="yellow"/>
       <origin rpy="1.57 0 0" xyz="-0.01925 0.0067 -0.0125"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/crossbrace.stl"/>
+      </geometry>
+      <material name="yellow"/>
+      <origin rpy="1.57 0 0" xyz="-0.01925 0.0067 -0.0125"/>
+    </collision>
   </link>
-
   <joint name="right_foot_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.05"/>
     <mimic joint="right_knee_servo_link_joint" multiplier="-1" offset="0"/>
@@ -934,6 +1243,12 @@
       <material name="blue"/>
       <origin rpy="1.57 0 0" xyz="-0.03225 0.0143 -0.00725"/>
     </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://marty_description/meshes/foot.stl"/>
+      </geometry>
+      <material name="blue"/>
+      <origin rpy="1.57 0 0" xyz="-0.03225 0.0143 -0.00725"/>
+    </collision>
   </link>
-
 </robot>


### PR DESCRIPTION
This currently simply uses the full mesh models. Most of them should be replaced with shape primitives in the future for faster simulation speed (or simplification of the CAD meshes).

Next up should be adding mass and inertial (for physics simulation).

This is a first step to resolving #2 